### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -4,7 +4,7 @@
     "version"     : "0.2.0",
     "description" : "Provides functions to gather and filter process times for a user command",
     "authors"     : [ "github:tbrowder" ],
-    "license"     : "Artistic 2.0",
+    "license"     : "Artistic-2.0",
     "source-url"  : "https://github.com/tbrowder/Linux-Proc-Time-Perl6/archive/v0.2.0.zip",
     "support"     : {
         "bugtracker" : "https://github.com/tbrowder/Linux-Proc-Time-Perl6/issues",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license